### PR TITLE
First implementation: Route Tree

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 	},
 	"suggest": {
 		"symfony/expression-language": "To support security expressions in the menu",
-		"symfony/routing": "For using linkable menu items",
+		"symfony/routing": "For using linkable menu items and the route trees",
 		"symfony/security-core": "To support security expressions in the menu",
 		"symfony/translation-contracts": "For using translatable menu items"
 	},

--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,15 @@
 		"symfony/phpunit-bridge": "^6.1",
 		"symfony/routing": "^6.1",
 		"symfony/security-core": "^6.1",
-		"symfony/translation": "^6.1"
+		"symfony/translation": "^6.1",
+		"twig/twig": "^3.4"
 	},
 	"suggest": {
 		"symfony/expression-language": "To support security expressions in the menu",
 		"symfony/routing": "For using linkable menu items and the route trees",
 		"symfony/security-core": "To support security expressions in the menu",
-		"symfony/translation-contracts": "For using translatable menu items"
+		"symfony/translation-contracts": "For using translatable menu items",
+		"twig/twig": "To add the render_route_menu() and render_menu() twig functions"
 	},
 	"autoload": {
 		"psr-4": {

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,0 +1,16 @@
+services:
+    _defaults:
+        autoconfigure: true
+        autowire: true
+
+    Torr\MenuBundle\:
+        resource: ../src/*
+        exclude:
+            - ../src/Exception
+            - ../src/Item
+            - ../src/Render/Options
+            - ../src/RouteTree/Collection
+            - ../src/RouteTree/Exception
+            - ../src/RouteTree/Options
+            - ../src/RouteTree/Tree
+            - ../src/TorrMenuBundle.php

--- a/src/Render/Options/RenderOptions.php
+++ b/src/Render/Options/RenderOptions.php
@@ -16,7 +16,7 @@ final class RenderOptions
 		 */
 		public readonly ?string $levelClass = null,
 		/**
-		 * The locale to translated the labels to
+		 * The locale to translate the labels to
 		 */
 		public readonly ?string $locale = null,
 	) {}

--- a/src/Render/Options/RenderOptions.php
+++ b/src/Render/Options/RenderOptions.php
@@ -20,4 +20,23 @@ final class RenderOptions
 		 */
 		public readonly ?string $locale = null,
 	) {}
+
+	/**
+	 *
+	 */
+	public static function fromArray (array $data) : self
+	{
+		$filtered = [];
+		$definedProperties = get_object_vars(new self());
+
+		foreach ($data as $key => $value)
+		{
+			if (\array_key_exists($key, $definedProperties))
+			{
+				$filtered[$key] = $value;
+			}
+		}
+
+		return new self(...$filtered);
+	}
 }

--- a/src/RouteTree/Collection/RouteTreeCollection.php
+++ b/src/RouteTree/Collection/RouteTreeCollection.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Torr\MenuBundle\RouteTree\Collection;
+
+use Torr\MenuBundle\RouteTree\Tree\RouteTreeNode;
+
+final class RouteTreeCollection
+{
+	/**
+	 *
+	 */
+	private readonly array $nodes;
+
+	/**
+	 * @param iterable<RouteTreeNode> $nodes
+	 */
+	public function __construct (
+		iterable $nodes,
+	)
+	{
+		$indexed = [];
+
+		foreach ($nodes as $node)
+		{
+			$indexed[$node->getRoute()] = $node;
+		}
+
+		$this->nodes = $indexed;
+	}
+
+	/**
+	 */
+	public function getNodeByRoute (string $route) : ?RouteTreeNode
+	{
+		return $this->nodes[$route] ?? null;
+	}
+}

--- a/src/RouteTree/Exception/InvalidRouteOptionsConfigurationException.php
+++ b/src/RouteTree/Exception/InvalidRouteOptionsConfigurationException.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Torr\MenuBundle\RouteTree\Exception;
+
+use Torr\MenuBundle\Exception\MenuException;
+
+final class InvalidRouteOptionsConfigurationException extends \InvalidArgumentException implements MenuException
+{
+}

--- a/src/RouteTree/Exception/InvalidRouteTreeException.php
+++ b/src/RouteTree/Exception/InvalidRouteTreeException.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Torr\MenuBundle\RouteTree\Exception;
+
+use Torr\MenuBundle\Exception\MenuException;
+
+final class InvalidRouteTreeException extends \RuntimeException implements MenuException
+{
+}

--- a/src/RouteTree/Exception/UnknownRouteNameException.php
+++ b/src/RouteTree/Exception/UnknownRouteNameException.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Torr\MenuBundle\RouteTree\Exception;
+
+use Torr\MenuBundle\Exception\MenuException;
+
+final class UnknownRouteNameException extends \RuntimeException implements MenuException
+{
+}

--- a/src/RouteTree/Loader/RouteTreeLoader.php
+++ b/src/RouteTree/Loader/RouteTreeLoader.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+
+namespace Torr\MenuBundle\RouteTree\Loader;
+
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\RouterInterface;
+use Torr\MenuBundle\Exception\MissingDependencyException;
+use Torr\MenuBundle\RouteTree\Collection\RouteTreeCollection;
+use Torr\MenuBundle\RouteTree\Exception\InvalidRouteOptionsConfigurationException;
+use Torr\MenuBundle\RouteTree\Tree\RouteTreeNode;
+
+final class RouteTreeLoader
+{
+	public function __construct (
+		private readonly ?RouterInterface $router,
+	) {}
+
+	public function loadTree () : RouteTreeCollection
+	{
+		if (null === $this->router)
+		{
+			throw new MissingDependencyException("Can't use the route tree without a router.");
+		}
+
+		$configuredRoutes = [];
+		$parentsMap = [];
+
+		// region Generate route tree nodes
+		foreach ($this->router->getRouteCollection() as $routeKey => $route)
+		{
+			$menuConfig = $route->getOption("menu");
+
+			// skip unconfigured routes
+			if (null === $menuConfig)
+			{
+				continue;
+			}
+
+			if (\is_string($menuConfig))
+			{
+				$menuConfig = ["parent" => $menuConfig];
+			}
+
+			if (!\is_array($menuConfig))
+			{
+				throw new InvalidRouteOptionsConfigurationException(\sprintf(
+					"Invalid route '%s': The route options must either be a string or an array.",
+					$routeKey,
+				));
+			}
+
+			$parent = $menuConfig["parent"] ?? null;
+
+			if (!\is_string($parent))
+			{
+				throw new InvalidRouteOptionsConfigurationException(\sprintf(
+					"Invalid route '%s':  The 'parent' option is required and must be a string.",
+					$routeKey,
+				));
+			}
+
+			$configuredRoutes[$routeKey] = RouteTreeNode::fromArray($routeKey, $menuConfig);
+			$parentsMap[$routeKey] = $parent;
+		}
+		// endregion
+
+		// region Map Parents
+		$configuredRoutes = $this->mapParents($parentsMap, $configuredRoutes);
+		// endregion
+
+		return new RouteTreeCollection($configuredRoutes);
+	}
+
+
+	/**
+	 * @param array<string, string>        $parentsMap
+	 * @param array<string, RouteTreeNode> $configuredRoutes
+	 *
+	 * @return array<string, RouteTreeNode>
+	 */
+	private function mapParents (
+		array $parentsMap,
+		array $configuredRoutes,
+	) : array
+	{
+		foreach ($parentsMap as $childRouteName => $parentRouteName)
+		{
+			$childNode = $configuredRoutes[$childRouteName];
+			\assert($childNode instanceof RouteTreeNode);
+			$parentNode = $configuredRoutes[$parentRouteName] ?? null;
+
+			// if parent does not exist, create it lazily
+			if (null === $parentNode)
+			{
+				$parentNode = new RouteTreeNode($parentRouteName);
+				$configuredRoutes[$parentRouteName] = $parentNode;
+			}
+
+			$parentNode->addChild($childNode);
+		}
+
+		return $configuredRoutes;
+	}
+}

--- a/src/RouteTree/Options/RouteTreeOptions.php
+++ b/src/RouteTree/Options/RouteTreeOptions.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Torr\MenuBundle\RouteTree\Options;
+
+final class RouteTreeOptions
+{
+	/**
+	 */
+	public function __construct (
+		private readonly ?string $translationDomain = null,
+	) {}
+
+	/**
+	 */
+	public function getTranslationDomain () : ?string
+	{
+		return $this->translationDomain;
+	}
+
+	/**
+	 */
+	public static function fromArray (array $data) : self
+	{
+		return new self(
+			translationDomain: $data["translationDomain"] ?? null,
+		);
+	}
+}

--- a/src/RouteTree/Render/RouteMenuRenderer.php
+++ b/src/RouteTree/Render/RouteMenuRenderer.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace Torr\MenuBundle\RouteTree\Render;
+
+use Torr\MenuBundle\Render\MenuRenderer;
+use Torr\MenuBundle\Render\Options\RenderOptions;
+use Torr\MenuBundle\RouteTree\Exception\UnknownRouteNameException;
+use Torr\MenuBundle\RouteTree\Loader\RouteTreeLoader;
+use Torr\MenuBundle\RouteTree\Options\RouteTreeOptions;
+use Torr\MenuBundle\RouteTree\Transformer\RouteTreeTransformHelper;
+
+final class RouteMenuRenderer
+{
+	public function __construct (
+		private readonly RouteTreeLoader $loader,
+		private readonly RouteTreeTransformHelper $transformHelper,
+		private readonly MenuRenderer $menuRenderer,
+	) {}
+
+	public function render (
+		string $routeName,
+		RouteTreeOptions $routeTreeOptions = new RouteTreeOptions(),
+		RenderOptions $renderOptions = new RenderOptions(),
+	) : string
+	{
+		$tree = $this->loader->loadTree();
+		$node = $tree->getNodeByRoute($routeName);
+
+		if (null === $node)
+		{
+			throw new UnknownRouteNameException(\sprintf(
+				"Route '%s' does not exist or is not used in a tree.",
+				$routeName,
+			));
+		}
+
+		$menu = $node->toMenuItem($this->transformHelper, $routeTreeOptions);
+		return $this->menuRenderer->render($menu, $renderOptions);
+	}
+}

--- a/src/RouteTree/Transformer/RouteTreeTransformHelper.php
+++ b/src/RouteTree/Transformer/RouteTreeTransformHelper.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+namespace Torr\MenuBundle\RouteTree\Transformer;
+
+use Symfony\Component\Security\Core\Security;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Torr\MenuBundle\Exception\MissingDependencyException;
+use Torr\MenuBundle\Item\MenuItem;
+
+final class RouteTreeTransformHelper
+{
+	/**
+	 */
+	public function __construct (
+		private readonly ?TranslatorInterface $translator,
+		private readonly ?Security $security,
+	) {}
+
+
+	/**
+	 *
+	 */
+	public function translate (
+		?string $label,
+		?string $translationDomain,
+	) : ?string
+	{
+		if (null === $label || null === $translationDomain)
+		{
+			return $label;
+		}
+
+		if (null === $this->translator)
+		{
+			throw new MissingDependencyException("Can't use translatable routes without a translator.");
+		}
+
+		return $this->translator->trans($label, domain: $translationDomain);
+	}
+
+
+	/**
+	 * Sorts the given menu items
+	 *
+	 * @return MenuItem[]
+	 */
+	public function sortMenuItems (array $items) : array
+	{
+		\usort(
+			$items,
+			static function (MenuItem $left, MenuItem $right) : int
+			{
+				// order by priority desc by default
+				$priorityDifference = $right->getExtra("priority", 0) - $left->getExtra("priority", 0);
+
+				// if the same priority -> sort alphabetically asc
+				if (0 === $priorityDifference)
+				{
+					$leftLabel = $left->getLabel();
+					$rightLabel = $right->getLabel();
+
+					// the route tree only generates already translated menu items
+					\assert(null === $leftLabel || \is_string($leftLabel));
+					\assert(null === $rightLabel || \is_string($rightLabel));
+
+					return \strnatcasecmp((string) $leftLabel, (string) $rightLabel);
+				}
+
+				return $priorityDifference;
+			},
+		);
+
+		return $items;
+	}
+
+
+	/**
+	 * Returns whether the security expression is currently accessible
+	 */
+	public function isAccessible (?string $security) : bool
+	{
+		if (null === $security)
+		{
+			return true;
+		}
+
+		if (null === $this->security)
+		{
+			throw new MissingDependencyException("Can't use security settings if the security bundle is not installed.");
+		}
+
+		return $this->security->isGranted($security);
+	}
+}

--- a/src/RouteTree/Tree/RouteTreeNode.php
+++ b/src/RouteTree/Tree/RouteTreeNode.php
@@ -1,0 +1,106 @@
+<?php declare(strict_types=1);
+
+namespace Torr\MenuBundle\RouteTree\Tree;
+
+use Torr\MenuBundle\Item\MenuItem;
+use Torr\MenuBundle\RouteTree\Exception\InvalidRouteTreeException;
+use Torr\MenuBundle\RouteTree\Options\RouteTreeOptions;
+use Torr\MenuBundle\RouteTree\Transformer\RouteTreeTransformHelper;
+use Torr\Rad\Route\Linkable;
+
+final class RouteTreeNode
+{
+	private ?self $parent = null;
+	/** @var self[] */
+	private array $children = [];
+
+	/**
+	 */
+	public function __construct (
+		private readonly string $route,
+		private readonly array $routeParameters = [],
+		private readonly ?string $label = null,
+		private readonly bool $sort = false,
+		private readonly ?string $security = null,
+		private readonly int $priority = 0,
+		private readonly bool $hidden = false,
+	) {}
+
+	/**
+	 */
+	public function getRoute () : string
+	{
+		return $this->route;
+	}
+
+
+	/**
+	 *
+	 */
+	public function addChild (self $child) : void
+	{
+		if (null !== $child->parent)
+		{
+			throw new InvalidRouteTreeException(\sprintf(
+				"Can't add child '%s' to parent '%s' as it already has a parent ('%s')",
+				$child->route,
+				$this->route,
+				$child->parent->route,
+			));
+		}
+
+		$child->parent = $this;
+		$this->children[] = $child;
+	}
+
+
+	/**
+	 * Transforms the route tree to a menu item tree
+	 */
+	public function toMenuItem (
+		RouteTreeTransformHelper $transformHelper,
+		RouteTreeOptions $options,
+	) : MenuItem
+	{
+		$menuItem = new MenuItem(
+			label: $transformHelper->translate($this->label, $options->getTranslationDomain()),
+			target: new Linkable($this->route, $this->routeParameters),
+			extras: [
+				"priority" => $this->priority,
+			],
+			visible: !$this->hidden && $transformHelper->isAccessible($this->security),
+		);
+
+		// handle children
+		$children = [];
+
+		foreach ($this->children as $child)
+		{
+			$children[] = $child->toMenuItem($transformHelper, $options);
+		}
+
+		// handle sorting
+		if ($this->sort)
+		{
+			$children = $transformHelper->sortMenuItems($children);
+		}
+
+
+		// add to parent
+		\array_map(
+			$menuItem->addChild(...),
+			$children,
+		);
+
+		return $menuItem;
+	}
+
+
+	public static function fromArray (string $route, array $config) : self
+	{
+		$config["route"] = $route;
+		unset($config["parent"]);
+
+		return new self(...$config);
+	}
+}

--- a/src/Twig/MenuTwigExtension.php
+++ b/src/Twig/MenuTwigExtension.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Torr\MenuBundle\Twig;
+
+use Torr\MenuBundle\Item\MenuItem;
+use Torr\MenuBundle\Render\MenuRenderer;
+use Torr\MenuBundle\Render\Options\RenderOptions;
+use Torr\MenuBundle\RouteTree\Options\RouteTreeOptions;
+use Torr\MenuBundle\RouteTree\Render\RouteMenuRenderer;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class MenuTwigExtension extends AbstractExtension
+{
+	/**
+	 */
+	public function __construct (
+		private readonly MenuRenderer $menuRenderer,
+		private readonly RouteMenuRenderer $routeMenuRenderer,
+	) {}
+
+
+	public function renderMenu (MenuItem $item, array $options = []) : string
+	{
+		return $this->menuRenderer->render($item, RenderOptions::fromArray($options));
+	}
+
+	public function renderRouteMenu (string $routeName, array $options = []) : string
+	{
+		return $this->routeMenuRenderer->render(
+			$routeName,
+			RouteTreeOptions::fromArray($options),
+			RenderOptions::fromArray($options),
+		);
+	}
+
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getFunctions () : array
+	{
+		$safeHtml = ["is_safe" => ["html"]];
+
+		return [
+			new TwigFunction("menu_render", $this->renderMenu(...), $safeHtml),
+			new TwigFunction("route_menu_render", $this->renderRouteMenu(...), $safeHtml),
+		];
+	}
+}


### PR DESCRIPTION
This is the first implementation of the route tree.

What will be added in a follow up PR

- Tests for `::fromArray()`
- Tests for the generation
- Caching for the route tree loader
- test (or if possible: add tests) for usage without optional dependencies